### PR TITLE
State persistence feature

### DIFF
--- a/src/app/Containers/VisualContainer/index.tsx
+++ b/src/app/Containers/VisualContainer/index.tsx
@@ -24,6 +24,9 @@ const VisualContainer: React.FC<VisualContainerProps> = ({
   previousSnapshot,
   currentSnapshot,
 }) => {
+  // state for checkmark in persist state in settings
+  const [checked, setChecked] = useState(false);
+
   // conditional render of filtered snaps/ based on non-filtered snaps
   const filteredCurSnap = currentSnapshot
     ? currentSnapshot.filteredSnapshot
@@ -56,7 +59,7 @@ const VisualContainer: React.FC<VisualContainerProps> = ({
         filteredCurSnap={filteredCurSnap}
       />
     ),
-    Settings: <Settings />,
+    Settings: <Settings checked={checked} setChecked={setChecked} />,
   };
   // array of all nav obj keys
   const tabsList = Object.keys(nav);

--- a/src/app/components/Settings/SettingsComponents/StateSettings.tsx
+++ b/src/app/components/Settings/SettingsComponents/StateSettings.tsx
@@ -1,8 +1,15 @@
 import React, {useState} from 'react';
 
-const StateSettings: React.FC = () => {
+interface StateSettingsProps {
+  checked: boolean;
+  setChecked: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const StateSettings: React.FC<StateSettingsProps> = ({checked, setChecked}) => {
   // functionality to postMessage the selected snapshot index to background.js
   const persistStateFunc = () => {
+    // setChecked as true
+    setChecked(true);
     // variable to store/reference connection
     const backgroundConnection = chrome.runtime.connect();
     // post the message with index in payload to the connection
@@ -14,8 +21,11 @@ const StateSettings: React.FC = () => {
   return (
     <div>
       <h2>Persist State</h2>
-      <input type="checkbox" onChange={persistStateFunc}></input> Checkmark to
-      Save State
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={persistStateFunc}></input>{' '}
+      Checkmark to Save State
     </div>
   );
 };

--- a/src/app/components/Settings/index.tsx
+++ b/src/app/components/Settings/index.tsx
@@ -15,12 +15,17 @@ import AtomSettings from './SettingsComponents/AtomSettings';
 //   filteredCurSnap: filteredSnapshot;
 // }
 
+interface StateSettingsProps {
+  checked: boolean;
+  setChecked: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
 // renders the difference between the most recent state change and the previous
-const Settings: React.FC = () => {
+const Settings: React.FC<StateSettingsProps> = ({checked, setChecked}) => {
   return (
     <div className="Settings">
       <AtomSettings />
-      <StateSettings />
+      <StateSettings checked={checked} setChecked={setChecked} />
       <ThrottleSettings />
     </div>
   );

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -46,9 +46,6 @@ chrome.runtime.onConnect.addListener(port => {
 
       case 'persistState':
         if (tabId) {
-          chrome.extension
-            .getBackgroundPage()
-            .window.console.log('message received in background');
           // if msg tabId provided, send persistState command to content-script
           chrome.tabs.sendMessage(Number(tabId), msg);
         }
@@ -145,10 +142,6 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
       });
       break;
     case 'persistSnapshots':
-      chrome.extension
-        .getBackgroundPage()
-        .window.console.log('tabIDssssss', tabId);
-
       // getting the array of filtered snapshots that exists on locoal storage
       chrome.storage.local.get(tabId, function (result) {
         console.log('storage values', result[tabId]);


### PR DESCRIPTION
For a comprehensive code changes and commits, please look at this PR https://github.com/oslabs-beta/Recoilize/pull/5

## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [x] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
- State persistence feature added to Recoilize. Developers now have the option to save their application's state in Recoilize and will persist through a refresh or reload.

## Approach
<!--- How does your change address the problem? -->
- Added functionality in the front end to send a message to background/content-script whenever state persistence checkbox is checked.
- Content script/background will relay the message to the module to save the current state and trigger state persist mode.
- With state persist mode turned on, saved state will be reloaded on refresh.

## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
- Communication and data flow between Recoilize's frontend, extension, and the module
- How to persist state using Web Storage API's including local and session storage as well as indexedDB
- Under the hood of Recoil's snapshots of state (how snapshots are taken, how the changes are tracked, and etc)
- Serializing and deserializing of a class instance
- Structure and algorithm of React Fiber

## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->

Before Refresh
![image](https://user-images.githubusercontent.com/58493724/90274625-c5a7a800-de15-11ea-91d9-d84e05ffce6a.png)

After Refresh
![image](https://user-images.githubusercontent.com/58493724/90274709-e2dc7680-de15-11ea-8680-6b3b8f31f9c7.png)

## Notes
 - State persistence feature is not 100% complete and still has some bugs. The persisted state can be viewed in the extension, but the application state itself is lost through refresh. You can time travel to the new state, but not the old.




