### PR TITLE
optimized backend throttle to match with frontend snapshot

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -14,24 +14,12 @@ let isRestoredState = false;
 
 // throttle is an object that keeps track of the throttle settings made by the user
 let throttleTimer = 0;
-let throttleLimit = 0;
+let throttleLimit = 70;
 
 // persistedSnapshots initially null
 // let persistedSnapshots = null;
 
 export default function RecoilizeDebugger(props) {
-  // ! the props can go here, a message can be made to edit the global object for throttling
-  const throttle = () => {
-    const now = new Date().getTime();
-    // if we get a series of 5 in a row called super fast, then we want to turn the throttle on
-    if (now - throttleTimer < throttleLimit) {
-      isRestoredState = true;
-    } else {
-      throttleTimer = now;
-    }
-  };
-  throttle();
-
   // We should ask for Array of atoms and selectors.
   // Captures all atoms that were defined to get the initial state
 
@@ -201,6 +189,14 @@ export default function RecoilizeDebugger(props) {
 
   // FOR TIME TRAVEL: Recoil hook to fire a callback on every snapshot change
   useRecoilTransactionObserver_UNSTABLE(({snapshot}) => {
+    const now = new Date().getTime();
+    // if we get a series of 5 in a row called super fast, then we want to turn the throttle on
+    if (now - throttleTimer < throttleLimit) {
+      console.log('too quick');
+      isRestoredState = true;
+    } else {
+      throttleTimer = now;
+    }
     if (!isRestoredState) {
       setSnapshots([...snapshots, snapshot]);
     }


### PR DESCRIPTION
## Types of changes
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
We discovered that time travel through snapshots was not working.
## Approach
We narrowed the issue down realizing that the backend was generating snapshots at a much faster rate than the front end. We solved this by implementing a throttle to the backend so that frontend and backend will always have an equal number of snapshots. We plan to continue to optimize the background.

Co-authored-by: justinchoo93 <kchoosun@gmail.com>
Co-authored-by: hobaek <smilgaru@gmail.com>