### PR TITLE
Removed state graph tab visuals and included Metrics

### DIFF
--- a/src/app/Containers/VisualContainer.tsx
+++ b/src/app/Containers/VisualContainer.tsx
@@ -87,7 +87,7 @@ const VisualContainer: React.FC<VisualContainerProps> = ({
     'Atom Network': <Network filteredCurSnap={filteredCurSnap} />,
 
     // individual snapshot visualizer
-    'State Graph': <Visualizer filteredCurSnap={filteredCurSnap} />,
+    'Metrics': <Visualizer componentAtomTree={componentAtomTree} />,
 
     // settings tab that doesn't want to be in quotes because too cool for school
     Settings: (

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -89,8 +89,13 @@ const App: React.FC = () => {
     <MainContainer
       // array of snapshots
       snapshotHistory={snapshotHistory}
+
+      // selected will be an array with objects containing filteredSnapshot key names.
+      // ex: [{name: 'type'}, {name: 'contents'}, {name: 'nodeDeps'}, {name: 'nodeToNodeSubscriptions'}]
       selected={selected}
       setSelected={setSelected}
+
+      // Filter is an array of objects containing differences between snapshots.
       filter={filter}
     />
   );

--- a/src/app/components/StateGraph/Visualizer.tsx
+++ b/src/app/components/StateGraph/Visualizer.tsx
@@ -1,13 +1,13 @@
-import React, {useRef, useState, useEffect} from 'react';
+import React, {useRef, useState, useEffect, Children} from 'react';
 import * as d3 from 'd3';
 import makeTree from '../../utils/makeTreeConversion';
-import {filteredSnapshot} from '../../../types';
+import {componentAtomTree} from '../../../types';
 
 interface VisualizerProps {
-  filteredCurSnap: filteredSnapshot;
+  componentAtomTree: componentAtomTree;
 }
 
-const Visualizer: React.FC<VisualizerProps> = ({filteredCurSnap}) => {
+const Visualizer: React.FC<VisualizerProps> = ({componentAtomTree}) => {
   // set the heights and width of the tree to be passed into treeMap function
   let width = 0;
   let height = 0;
@@ -17,13 +17,27 @@ const Visualizer: React.FC<VisualizerProps> = ({filteredCurSnap}) => {
 
   useEffect(() => {
     setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
-  }, [filteredCurSnap]);
+  }, [componentAtomTree]);
 
   // this only clears the canvas if Visualizer is already rendered on the extension
   useEffect(() => {
     height = document.querySelector('.Visualizer').clientHeight;
     width = document.querySelector('.Visualizer').clientWidth;
     document.getElementById('canvas').innerHTML = '';
+    
+
+    const namesAndDurations = (node: any) => {
+      // const tagCheck = 0 | 1 | 13;
+      if(node.tag === 0 || node.tag === 1 || node.tag === 13){
+        console.log('Name: ', node.name, 'Actual Duration: ', node.actualDuration)
+      }
+      if(!node.children.length) return console.log("No children");
+      node.children.forEach((child: any) => namesAndDurations(child))
+      return console.log('Done going through children.')
+    }
+
+    namesAndDurations(componentAtomTree);
+
 
     // creating the main svg container for d3 elements
     const svgContainer: any = d3
@@ -37,106 +51,106 @@ const Visualizer: React.FC<VisualizerProps> = ({filteredCurSnap}) => {
       .attr('transform', `translate(${x}, ${y}), scale(${k})`); // sets the canvas to the saved zoomState
 
     // atomState is the object that is passed into d3.hierarchy
-    const atomState: any = {
-      name: 'Recoil Root',
-      // pass in parsed data here
-      // call the helper function passing in the most recent snapshot
-      children: makeTree(filteredCurSnap),
-    };
+    // const atomState: any = {
+    //   name: 'Recoil Root',
+    //   // pass in parsed data here
+    //   // call the helper function passing in the most recent snapshot
+    //   children: makeTree(filteredCurSnap),
+    // };
 
     // creating the tree map
     const treeMap: any = d3.tree().nodeSize([width, height]);
 
     // creating the nodes of the tree
     // pass
-    const hierarchyNodes: any = d3.hierarchy(atomState);
+    // const hierarchyNodes: any = d3.hierarchy(atomState);
 
     // calling the tree function with nodes created from data
-    const finalMap: any = treeMap(hierarchyNodes);
+    // const finalMap: any = treeMap(hierarchyNodes);
 
     // renders a flat array of objects containing all parent-child links
     // renders the paths onto the component
-    let paths: any = finalMap.links();
+    // let paths: any = finalMap.links();
 
     // this creates the paths to each atom and its contents in the tree
-    g.append('g')
-      .attr('fill', 'none')
-      .attr('stroke', '#646464')
-      .attr('stroke-width', 5)
-      .selectAll('path')
-      .data(paths)
-      .join('path')
-      .attr(
-        'd',
-        d3
-          .linkHorizontal()
-          .x((d: any) => d.y)
-          .y((d: any) => d.x),
-      );
+    // g.append('g')
+    //   .attr('fill', 'none')
+    //   .attr('stroke', '#646464')
+    //   .attr('stroke-width', 5)
+    //   .selectAll('path')
+    //   .data(paths)
+    //   .join('path')
+    //   .attr(
+    //     'd',
+    //     d3
+    //       .linkHorizontal()
+    //       .x((d: any) => d.y)
+    //       .y((d: any) => d.x),
+    //   );
 
     // returns a flat array of objects containing all the nodes and their information
     // renders nodes onto the canvas
-    let nodes: any = hierarchyNodes.descendants();
+    // let nodes: any = hierarchyNodes.descendants();
 
     // const node is used to create all the nodes
     // this segment places all the nodes on the canvas
-    const node: any = g
-      .append('g')
-      .attr('stroke-linejoin', 'round') // no clue what this does
-      .attr('stroke-width', 1)
-      .selectAll('g')
-      .data(nodes)
-      .join('g')
-      .attr('transform', (d: any) => `translate(${d.y}, ${d.x})`)
-      .attr('class', 'atomNodes');
+    // const node: any = g
+    //   .append('g')
+    //   .attr('stroke-linejoin', 'round') // no clue what this does
+    //   .attr('stroke-width', 1)
+    //   .selectAll('g')
+    //   .data(nodes)
+    //   .join('g')
+    //   .attr('transform', (d: any) => `translate(${d.y}, ${d.x})`)
+    //   .attr('class', 'atomNodes');
 
     // for each node that got created, append a circle element
-    node.append('circle').attr('fill', '#c300ff').attr('r', 50);
+    // node.append('circle').attr('fill', '#c300ff').attr('r', 50);
 
-    // for each node that got created, append a text element that displays the name of the node
-    node
-      .append('text')
-      .attr('dy', '.31em')
-      .attr('x', (d: any) => (d.children ? -75 : 75))
-      .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
-      .text((d: any) => d.data.name)
-      .style('font-size', `3.5rem`)
-      .style('fill', 'white')
-      .clone(true)
-      .lower()
-      .attr('stroke', '#646464')
-      .attr('stroke-width', 2);
+    // // for each node that got created, append a text element that displays the name of the node
+    // node
+    //   .append('text')
+    //   .attr('dy', '.31em')
+    //   .attr('x', (d: any) => (d.children ? -75 : 75))
+    //   .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
+    //   .text((d: any) => d.data.name)
+    //   .style('font-size', `3.5rem`)
+    //   .style('fill', 'white')
+    //   .clone(true)
+    //   .lower()
+    //   .attr('stroke', '#646464')
+    //   .attr('stroke-width', 2);
 
-    // adding a mouseOver event handler to each node
-    // only add popup text on nodes with no children
-    // display the data in the node on hover
-    node.on('mouseover', function (d: any, i: number): any {
-      if (!d.children) {
-        d3.select(this)
-          .append('text')
-          .text(JSON.stringify(d.data, undefined, 2))
-          .style('fill', 'white')
-          .attr('x', 75)
-          .attr('y', 60)
-          .style('font-size', '4rem')
-          .attr('stroke', '#646464')
-          .attr('id', `popup${i}`);
-      }
-    });
+    // // adding a mouseOver event handler to each node
+    // // only add popup text on nodes with no children
+    // // display the data in the node on hover
+    // node.on('mouseover', function (d: any, i: number): any {
+    //   if (!d.children) {
+    //     d3.select(this)
+    //       .append('text')
+    //       .text(JSON.stringify(d.data, undefined, 2))
+    //       .style('fill', 'white')
+    //       .attr('x', 75)
+    //       .attr('y', 60)
+    //       .style('font-size', '4rem')
+    //       .attr('stroke', '#646464')
+    //       .attr('id', `popup${i}`);
+    //   }
+    // });
 
-    // add mouseOut event handler that removes the popup text
-    node.on('mouseout', function (d: any, i: number): any {
-      d3.select(`#popup${i}`).remove();
-    });
+    // // add mouseOut event handler that removes the popup text
+    // node.on('mouseout', function (d: any, i: number): any {
+    //   d3.select(`#popup${i}`).remove();
+    // });
 
-    // allows the canvas to be draggable
-    node.call(
-      d3
-        .drag()
-        .on('start', dragStarted)
-        .on('drag', dragged)
-        .on('end', dragEnded),
-    );
+    // // allows the canvas to be draggable
+    // node.call(
+    //   d3
+    //     .drag()
+    //     .on('start', dragStarted)
+    //     .on('drag', dragged)
+    //     .on('end', dragEnded),
+    // );
 
     // helper functions that help with dragging functionality
     function dragStarted(): any {

--- a/src/extension/build/devtools.js
+++ b/src/extension/build/devtools.js
@@ -1,6 +1,6 @@
 // The initial script that loads the extension into the DevTools panel.
 chrome.devtools.panels.create(
-  'Recoilize', // title of devtool panel
+  'Production', // title of devtool panel
   '../assets/covalent-recoil-logo.jpg', // icon of devtool panel
   'panel.html', // html of devtool panel
 );

--- a/src/extension/build/manifest.json
+++ b/src/extension/build/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Recoilize",
-  "version": "0.8.0",
+  "name": "Production",
+  "version": "0.8.5",
   "devtools_page": "devtools.html",
   "description": "A Chrome extension that helps debug Recoil applications by memorizing the state of components with every render.",
   "manifest_version": 2,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -26,6 +26,7 @@ export type componentAtomTree = {
   name: string;
   tag: number;
   recoilNodes: string[];
+  actualDuration: number;
 };
 
 //////////////////////////


### PR DESCRIPTION
Co-authored-by: Aaron Yang <aaronyang024@gmail.com>

## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
To replace the state graph tab with a metrics tab.
## Approach
Renamed 'State Graph' to 'Metrics'. Removed the state graph visuals. Replaced the state nodes with the fiber tree nodes props.
## Learning
Reviewed flow of data from the Recoilize npm module to the dev tool front-end.
## Screenshot(s)
![Screen Shot 2020-10-03 at 10 15 45 AM](https://user-images.githubusercontent.com/25422789/94997681-908c1c00-0561-11eb-8136-f40668d025a9.png)
![Screen Shot 2020-10-03 at 10 16 19 AM](https://user-images.githubusercontent.com/25422789/94997682-941fa300-0561-11eb-89c3-84abe4ff324f.png)
