### PR TITLE
Fixed Off-By-One error in Time Travel

### DIFF
--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -72,10 +72,9 @@ const assignName = node => {
   if (node.tag === 5) return `${node.type}`;
   // Tag 3 === HostRoot
   if (node.tag === 3) return 'HR';
-  // Tag 3 === HostText
-  if (node.tag === 6) {
-    return node.memoizedProps;
-  }
+  // Tag 6 === HostText
+  if (node.tag === 6) return node.memoizedProps;
+  // Tag 7 === Fragment
   if (node.tag === 7) return 'Fragment';
 };
 

--- a/package/index.js
+++ b/package/index.js
@@ -10,6 +10,7 @@ import {formatFiberNodes} from './formatFiberNodes';
 let isPersistedState = sessionStorage.getItem('isPersistedState');
 
 // isRestored state disables snapshots from being recorded
+// when we jump backwards
 let isRestoredState = false;
 
 // set default throttle to 70, throttle timer changes with every snapshot

--- a/package/index.js
+++ b/package/index.js
@@ -110,7 +110,13 @@ export default function RecoilizeDebugger(props) {
           const initialFilteredSnapshot = formatAtomSelectorRelationship(
             filteredSnapshot,
           );
-          const devToolData = createDevToolDataObject(initialFilteredSnapshot);
+          
+          //creating a indexDiff variable
+          //only created on initial creation of devToolData
+          //determines difference in length of backend snapshots array and frontend snapshotHistoryLength to avoid off by one error
+          const indexDiff = snapshots.length - 1;
+
+          const devToolData = createDevToolDataObject(initialFilteredSnapshot, indexDiff);
           sendWindowMessage('moduleInitialized', devToolData);
         } else {
           setProperIndexForPersistedState();
@@ -204,6 +210,7 @@ export default function RecoilizeDebugger(props) {
     // await setRestoredState(false);
 
     isRestoredState = true;
+    
     await gotoSnapshot(snapshots[msg.data.payload.snapshotIndex]);
   };
 

--- a/src/app/Containers/SnapshotContainer.tsx
+++ b/src/app/Containers/SnapshotContainer.tsx
@@ -24,6 +24,7 @@ const SnapshotsContainer: React.FC<SnapshotsContainerProps> = ({
   const timeTravelFunc = (index: number) => {
     // variable to store/reference connection
     const backgroundConnection = chrome.runtime.connect();
+    const test = chrome.extension.getBackgroundPage();
     // post the message with index in payload to the connection
     backgroundConnection.postMessage({
       action: 'snapshotTimeTravel',

--- a/src/app/Containers/SnapshotContainer.tsx
+++ b/src/app/Containers/SnapshotContainer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SnapshotsList from '../components/SnapshotList/SnapshotList';
 import {stateSnapshot, selectedTypes} from '../../types';
+import { number } from 'prop-types';
 
 interface SnapshotsContainerProps {
   // index of current snapshot rendered in devtool
@@ -20,16 +21,22 @@ const SnapshotsContainer: React.FC<SnapshotsContainerProps> = ({
   selected,
   filter,
 }) => {
+  //indexDiff is used to ensure the index of filter matches the index of the snapshots array in the backend
+  let indexDiff: number = 0;
+  if(filter[0] && filter[0].indexDiff){
+    indexDiff = filter[0].indexDiff;
+  }
+  
   // functionality to postMessage the selected snapshot index to background.js
   const timeTravelFunc = (index: number) => {
     // variable to store/reference connection
     const backgroundConnection = chrome.runtime.connect();
-    const test = chrome.extension.getBackgroundPage();
+    //const test = chrome.extension.getBackgroundPage();
     // post the message with index in payload to the connection
     backgroundConnection.postMessage({
       action: 'snapshotTimeTravel',
       tabId: chrome.devtools.inspectedWindow.tabId,
-      payload: {snapshotIndex: index},
+      payload: {snapshotIndex: index + indexDiff},
     });
   };
   return (

--- a/src/app/Containers/VisualContainer.tsx
+++ b/src/app/Containers/VisualContainer.tsx
@@ -39,7 +39,6 @@ const VisualContainer: React.FC<VisualContainerProps> = ({
 }) => {
   // state for checkmark in persist state in settings
   const [checked, setChecked] = useState<boolean>(false);
-
   // variables to store/reference connection
   const [throttleDisplay, setThrottleDisplay] = useState<string>('70');
 

--- a/src/app/components/SnapshotList/SnapshotList.tsx
+++ b/src/app/components/SnapshotList/SnapshotList.tsx
@@ -74,7 +74,6 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
           setRenderIndex(i);
         }}>
         <li>{i}</li>
-        <span>{snapshotHistoryLength}</span>
         <button
           className="timeTravelButton"
           onClick={() => {

--- a/src/app/components/SnapshotList/SnapshotList.tsx
+++ b/src/app/components/SnapshotList/SnapshotList.tsx
@@ -74,6 +74,7 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
           setRenderIndex(i);
         }}>
         <li>{i}</li>
+        <span>{snapshotHistoryLength}</span>
         <button
           className="timeTravelButton"
           onClick={() => {

--- a/src/app/components/StateDiff/Diff.tsx
+++ b/src/app/components/StateDiff/Diff.tsx
@@ -8,6 +8,7 @@ interface DiffProps {
   filteredPrevSnap: filteredSnapshot;
   // snapshot at index [curRender]
   filteredCurSnap: filteredSnapshot;
+  //length of snapshotHistory
 }
 
 // renders the difference between the most recent state change and the previous

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -143,7 +143,7 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     case 'persistSnapshots':
       // getting the array of filtered snapshots that exists on locoal storage
       chrome.storage.local.get(tabId, function (result) {
-        console.log('storage values', result[tabId]);
+        
         connections[tabId].postMessage({
           action: 'recordSnapshot',
           payload: result[tabId],

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,6 +2,7 @@
 export type stateSnapshot = {
   filteredSnapshot: filteredSnapshot;
   componentAtomTree: componentAtomTree;
+  indexDiff?: number;
 };
 
 export type filteredSnapshot = {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Previously, the snapshots in the snapshot list contained indexes that would sometimes differ from the corresponding backend snapshot by one. This lead to any time-travel jump rendering the state of a different snapshot than desired to the browser.
## Approach
<!--- How does your change address the problem? -->
On the backend, when the initialFilteredSnapshot is used to make the initial call to createDevToolData, a second argument is passed in; indexDiff. This contains the difference in length from 1 of the snapshots array (which should have a length of 1 on the the first time createDevToolData is called). This index diff is added as a prop to the devToolData object and passed to the front. On the front end instead of sending index to the backend to determine which snapshot to jump to, it passes index + indexDiff. This ensures that the index being passed will match the intended index within the snapshots array on the backend.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
The research stage consisted mostly console logs to determine where the error was coming from, and how that differed from what data was being expected.

## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Screen Shot 2020-10-05 at 4 43 26 PM](https://user-images.githubusercontent.com/68144569/95143188-44d89e80-072a-11eb-9b4a-9e12b1b88ad5.png)
(An image showing that when a jump to snapshot 2 was made, the browser now reflects the state of the desired snapshot, as seen in the color's hex code matching that in 'State Diff' )