### PR TITLE
Fixed page reload dev tool crash.

### DIFF
--- a/src/app/Containers/MainContainer.tsx
+++ b/src/app/Containers/MainContainer.tsx
@@ -22,6 +22,9 @@ const MainContainer: React.FC<MainContainerProps> = ({
   const [renderIndex, setRenderIndex] = useState<number>(
     snapshotHistory.length - 1,
   );
+  // Will snapshot History ever be a length of 0?
+  console.log('renderIndex in MainContainer: ', renderIndex);
+  console.log('snapshotHistory in MainContainer: ',snapshotHistory)
 
   // Todo: usestate hook to update an array with all of the delta snapshots
 
@@ -43,7 +46,7 @@ const MainContainer: React.FC<MainContainerProps> = ({
         // ! passing through selected
         selected={selected}
         filter={filter}
-        currentSnapshot={snapshotHistory[renderIndex]}
+        snapshotHistory={snapshotHistory}
       />
       <VisualContainer
         // snapshot at index [renderIndex -1]

--- a/src/app/Containers/MainContainer.tsx
+++ b/src/app/Containers/MainContainer.tsx
@@ -1,14 +1,14 @@
 import React, {useState, useEffect} from 'react';
 import SnapshotsContainer from './SnapshotContainer';
 import VisualContainer from './VisualContainer';
-import {stateSnapshot, selectedTypes} from '../../types';
+import {stateSnapshot, selectedTypes, stateSnapshotDiff} from '../../types';
 
 interface MainContainerProps {
   // snapshotHistory is an array of stateSnapshots
   snapshotHistory: stateSnapshot[];
   selected: selectedTypes[];
   setSelected: React.Dispatch<React.SetStateAction<selectedTypes[]>>;
-  filter: stateSnapshot[];
+  filter: stateSnapshotDiff[];
 }
 
 // wraps entire application

--- a/src/app/Containers/MainContainer.tsx
+++ b/src/app/Containers/MainContainer.tsx
@@ -22,9 +22,6 @@ const MainContainer: React.FC<MainContainerProps> = ({
   const [renderIndex, setRenderIndex] = useState<number>(
     snapshotHistory.length - 1,
   );
-  // Will snapshot History ever be a length of 0?
-  console.log('renderIndex in MainContainer: ', renderIndex);
-  console.log('snapshotHistory in MainContainer: ',snapshotHistory)
 
   // Todo: usestate hook to update an array with all of the delta snapshots
 

--- a/src/app/Containers/SnapshotContainer.tsx
+++ b/src/app/Containers/SnapshotContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SnapshotsList from '../components/SnapshotList/SnapshotList';
-import {stateSnapshot, selectedTypes} from '../../types';
+import {stateSnapshot, selectedTypes, stateSnapshotDiff} from '../../types';
 import { number } from 'prop-types';
 
 interface SnapshotsContainerProps {
@@ -11,7 +11,7 @@ interface SnapshotsContainerProps {
   // setState functionality to update curRender
   setRenderIndex: React.Dispatch<React.SetStateAction<number>>;
   selected: selectedTypes[];
-  filter: stateSnapshot[];
+  filter: stateSnapshotDiff[];
   currentSnapshot: stateSnapshot;
 }
 

--- a/src/app/Containers/SnapshotContainer.tsx
+++ b/src/app/Containers/SnapshotContainer.tsx
@@ -12,7 +12,7 @@ interface SnapshotsContainerProps {
   setRenderIndex: React.Dispatch<React.SetStateAction<number>>;
   selected: selectedTypes[];
   filter: stateSnapshotDiff[];
-  currentSnapshot: stateSnapshot;
+  snapshotHistory: stateSnapshot[];
 }
 
 const SnapshotsContainer: React.FC<SnapshotsContainerProps> = ({
@@ -21,7 +21,7 @@ const SnapshotsContainer: React.FC<SnapshotsContainerProps> = ({
   setRenderIndex,
   selected,
   filter,
-  currentSnapshot,
+  snapshotHistory,
 }) => {
   //indexDiff is used to ensure the index of filter matches the index of the snapshots array in the backend
   let indexDiff: number = 0;
@@ -59,7 +59,7 @@ const SnapshotsContainer: React.FC<SnapshotsContainerProps> = ({
         timeTravelFunc={timeTravelFunc}
         selected={selected}
         filter={filter}
-        currentSnapshot={currentSnapshot}
+        snapshotHistory={snapshotHistory}
       />
     </div>
   );

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import MainContainer from '../Containers/MainContainer';
-import {stateSnapshot, selectedTypes} from '../../types';
+import {stateSnapshot, selectedTypes, stateSnapshotDiff} from '../../types';
 // importing the diff to find difference
 import {diff} from 'jsondiffpatch';
 const LOGO_URL = './assets/Recoilize.png';
@@ -11,7 +11,7 @@ const App: React.FC = () => {
   const [selected, setSelected] = useState<selectedTypes[]>([]);
 
   // todo: Create algo that will clean up the big setsnapshothistory object, now and before
-  let [filter, setFilter] = useState([]);
+  let [filter, setFilter] = useState<stateSnapshotDiff[]>([]);
   // ! Setting up the selected
   useEffect(() => {
     let last;
@@ -81,6 +81,8 @@ const App: React.FC = () => {
             setFilter(filter);
           }
         }
+        // Console log to inspect filter. Remove <code>
+        console.log('filter from App: ', filter)
       }
     });
   }, []);

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -81,8 +81,6 @@ const App: React.FC = () => {
             setFilter(filter);
           }
         }
-        // Console log to inspect filter. Remove <code>
-        console.log('filter from App: ', filter)
       }
     });
   }, []);

--- a/src/app/components/SnapshotList/SnapshotList.tsx
+++ b/src/app/components/SnapshotList/SnapshotList.tsx
@@ -12,7 +12,7 @@ interface SnapshotsListProps {
   timeTravelFunc: (index: number) => void;
   selected: selectedTypes[];
   filter: any[];
-  currentSnapshot: stateSnapshot;
+  snapshotHistory: stateSnapshot[];
 }
 
 const SnapshotsList: React.FC<SnapshotsListProps> = ({
@@ -22,7 +22,7 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
   timeTravelFunc,
   selected,
   filter,
-  currentSnapshot,
+  snapshotHistory,
 }) => {
   // useRef for a dummy div at the bottom of the scroll
   const snapshotEndRef = useRef<HTMLDivElement>(null);
@@ -65,12 +65,13 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
     if (x === false) {
       continue;
     }
-
+    
+    // renderTime is set equal to the actualDuration. If i is zero then we are obtaining actualDuration from the very first snapshot in snapshotHistory. This is to avoid having undefined filter elements since there will be no difference between snapshot at the first instance. 
     let renderTime: number;
-    //Checks to see if the actualDuration within filter is an array. If it is an array then the 2nd value in the array is the new actualDuration.
     if(i === 0) {
-      renderTime = currentSnapshot.componentAtomTree.actualDuration;
+      renderTime = snapshotHistory[0].componentAtomTree.actualDuration;
     } 
+    //Checks to see if the actualDuration within filter is an array. If it is an array then the 2nd value in the array is the new actualDuration.
     else if (Array.isArray(filter[i].componentAtomTree.actualDuration)) {
       renderTime = filter[i].componentAtomTree.actualDuration[1];
     } else {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -5,10 +5,21 @@ export type stateSnapshot = {
   indexDiff?: number;
 };
 
+// used for the filter state hook
+export type stateSnapshotDiff = {
+  filteredSnapshot?: filteredSnapshotDiff;
+  componentAtomTree?: componentAtomTreeDiff;
+  indexDiff?: number;
+}
+
 export type filteredSnapshot = {
   // key of atom name with the value of an atom
   [atomName: string]: node;
 };
+
+export type filteredSnapshotDiff = {
+  [atomName: string]: nodeDiff;
+}
 
 // object of either atom or selector
 export type node = {
@@ -22,6 +33,13 @@ export type node = {
   nodeToNodeSubscription: string[];
 };
 
+export type nodeDiff = {
+  string?: string | string[];
+  contents?: any;
+  nodeDeps?: string[] | string[][];
+  nodeToNodeSubscription?: string[] | string [][];
+}
+
 export type componentAtomTree = {
   children: object[];
   name: string;
@@ -29,6 +47,14 @@ export type componentAtomTree = {
   recoilNodes: string[];
   actualDuration: number;
 };
+
+export type componentAtomTreeDiff = {
+  children: object[] | object[][];
+  name: string | string[];
+  tag: number | number[];
+  recoilNodes: string[] | string[][];
+  actualDuration: number | number [];
+}
 
 //////////////////////////
 // TODO BE BETTER TYPED //


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The dev tool was crashing whenever the website under inspection was reloaded.
## Approach
The app was crashing because the snapshotList was expecting an object that had not yet been initialized. Rather than using the currenSnapshot value, the first element of snapshotHistory was used upon the first rendering of a webpage.
<!--- How does your change address the problem? -->
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Console logs were utilized to inspect the value of filter, snapshotHistory, and currentSnapshot arrays to determine which should be used to log the very first render time on the dev tool.