### PR TITLE
Toggle Button added to Metrics tab to switch between graphs

### DIFF
--- a/src/app/components/StateGraph/Metrics.tsx
+++ b/src/app/components/StateGraph/Metrics.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { ReactElement, useState } from 'react';
 import { hierarchy } from 'd3-hierarchy';
 import { ParentSize } from '@vx/responsive';
 import {componentAtomTree} from '../../../types';
 import IcicleVertical from './IcicleVertical';
+import Visualizer from './Visualizer';
 
 interface MetricsProps {
   componentAtomTree: componentAtomTree;
@@ -68,8 +69,44 @@ const cleanComponentAtomTree = (
 };
 
 
+
+
+
 const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
+  //create state for the graph type toggle
+  const [graphType, setGraphType] = useState<boolean>(true);
+
   const cleanedTree: any = cleanComponentAtomTree(componentAtomTree);
+
+  const toggleGraphFunc = (): void => {
+    graphType ? setGraphType(false) : setGraphType(true);
+  };
+
+
+  let sum = (x: number, y: number): number => {
+    return x + y;
+  }
+
+  const determineRender: any = () => {
+    if(graphType){
+      return(
+        <ParentSize>
+          {size =>
+            size.ref &&
+            <IcicleVertical root={root} width={size.width} height={600} />
+          }
+        </ParentSize>
+      );
+    }
+    else{
+      return(
+        //return the bar graph component
+        <Visualizer componentAtomTree={componentAtomTree}/>
+      );
+    }
+  }
+
+  const graph: any = determineRender();
 
   const root: any = hierarchy(cleanedTree)
   .eachBefore(
@@ -80,12 +117,19 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
 
   return (
     <div>
-      <ParentSize>
-        {size =>
-          size.ref &&
-          <IcicleVertical root={root} width={size.width} height={600} />
-        }
-      </ParentSize>
+      <div className="persistContainer">
+        <label className="switch" htmlFor="checkbox">
+          <input
+            data-testid="stateSettingsToggle"
+            id="checkbox"
+            type="checkbox"
+            checked={graphType}
+            onChange={toggleGraphFunc}></input>
+          <div className="slider round" />{' '}
+        </label>
+        <span className="persistText">Slide to Toggle Graph Type</span>
+      </div>
+      {graph}
     </div>
   );
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
There are two separate graphs to display render times. A way to switch between them was needed.
## Approach
<!--- How does your change address the problem? -->
A state variable was added (with useState hook) to Metrics.tsx which would hold true or false. A switch was rendered that toggles the state from true or false and depending on what state is either graph is conditionally rendered.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Using a switch element. First time diving into Aaron's code for the bar graph and attaching it to the rest of the metrics tab.
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Toggle_GIF_V1](https://user-images.githubusercontent.com/68144569/95419941-6931a800-08ef-11eb-959b-a1bea41b3514.gif)
