### PR TITLE
Render times list improvements.

### DIFF
--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -9,6 +9,7 @@ const formatFiberNodes = node => {
     children: [],
     recoilNodes: createAtomsSelectorArray(node),
     actualDuration: node.actualDuration,
+    treeBaseDuration: node.treeBaseDuration,
     wasSuspended: (node.return && node.return.tag === 13) ? true : false,
   };
 

--- a/package/formatFiberNodes.ts
+++ b/package/formatFiberNodes.ts
@@ -8,6 +8,7 @@ type node = {
   child: any;
   sibling: any;
   actualDuration: number;
+  treeBaseDuration: number;
   return: any;
 };
 
@@ -18,12 +19,14 @@ type formattedNode = {
   recoilNodes: any[];
   // adding in render time for fiber node
   actualDuration: number;
+  treeBaseDuration: number;
   wasSuspended: boolean;
 };
 
 const formatFiberNodes = (node: node) => {
   const formattedNode: formattedNode = {
     actualDuration: node.actualDuration,
+    treeBaseDuration: node.treeBaseDuration,
     // this function grabs a 'name' based on the tag of the node
     name: assignName(node),
     tag: node.tag,

--- a/src/app/components/SnapshotList/SnapshotList.tsx
+++ b/src/app/components/SnapshotList/SnapshotList.tsx
@@ -69,13 +69,13 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
     // renderTime is set equal to the actualDuration. If i is zero then we are obtaining actualDuration from the very first snapshot in snapshotHistory. This is to avoid having undefined filter elements since there will be no difference between snapshot at the first instance. 
     let renderTime: number;
     if(i === 0) {
-      renderTime = snapshotHistory[0].componentAtomTree.actualDuration;
+      renderTime = snapshotHistory[0].componentAtomTree.treeBaseDuration;
     } 
     //Checks to see if the actualDuration within filter is an array. If it is an array then the 2nd value in the array is the new actualDuration.
     else if (Array.isArray(filter[i].componentAtomTree.actualDuration)) {
-      renderTime = filter[i].componentAtomTree.actualDuration[1];
+      renderTime = filter[i].componentAtomTree.treeBaseDuration[1];
     } else {
-      renderTime = filter[i].componentAtomTree.actualDuration;
+      renderTime = filter[i].componentAtomTree.treeBaseDuration;
     }
 
     // Push a div container to snapshotDivs array only if there was a change to state. 

--- a/src/app/components/SnapshotList/SnapshotList.tsx
+++ b/src/app/components/SnapshotList/SnapshotList.tsx
@@ -96,6 +96,11 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
         <li>{`${Math.round(renderTime*100)/100}ms`}</li>
         <button
           className="timeTravelButton"
+          style={
+          renderIndex === i
+            ? {color: '#E6E6E6', backgroundColor: '#212121'}
+            : {color: '#989898'}
+          }
           onClick={() => {
             timeTravelFunc(i);
           }}>

--- a/src/app/components/SnapshotList/SnapshotList.tsx
+++ b/src/app/components/SnapshotList/SnapshotList.tsx
@@ -99,7 +99,7 @@ const SnapshotsList: React.FC<SnapshotsListProps> = ({
           style={
           renderIndex === i
             ? {color: '#E6E6E6', backgroundColor: '#212121'}
-            : {color: '#989898'}
+            : {}
           }
           onClick={() => {
             timeTravelFunc(i);

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -94,17 +94,21 @@ body {
   background-color: #212121;
 }
 
+.individualSnapshot .timeTravelButton:hover{
+  color: #e6e6e6;
+  border: 1px solid white;
+  background-color: #212121;
+  text-emphasis: bold;
+}
+
 .timeTravelButton {
-  border: none;
+  border: 1px solid #989898;
+  border-radius: 5px;
   color: #989898;
   background: none;
   outline: none;
 }
-.timeTravelButton:hover {
-  color: #e6e6e6;
-  background-color: #212121;
-  text-emphasis: bold;
-}
+
 .timeTravelButton:focus {
   color: #e6e6e6;
   background-color: #212121;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -46,6 +46,7 @@ export type componentAtomTree = {
   tag: number;
   recoilNodes: string[];
   actualDuration: number;
+  treeBaseDuration: number;
   wasSuspended: boolean;
 };
 
@@ -55,6 +56,7 @@ export type componentAtomTreeDiff = {
   tag: number | number[];
   recoilNodes: string[] | string[][];
   actualDuration: number | number [];
+  treeBaseDuration: number | number[];
   wasSuspended: boolean | boolean [];
 }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
To correct the render times being listed in the Snapshots section of the dev tool. Also to include styling for the jump button and add hovering effects.
## Approach
<!--- How does your change address the problem? -->
A new key was created in the formattedFiberNodes object. TreeBaseDuration was added and used for the render times rather than using the actualBaseDuration.
A style attribute was added when the jump buttons are rendered in the js file and hover effects were corrected in the css file. Existing hover effects in the css file were not going into effect due to priority issues.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Reviewed the actualDuration and treeBaseDuration of the React Fiber Node as a team. Little documentation exists for these values and further research is required. For now, it was decided that the treeBaseDuration is the closest estimate to the render duration of the react component and children as opposed to just the react component.
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
<img width="751" alt="Screen Shot 2020-10-08 at 1 27 07 PM" src="https://user-images.githubusercontent.com/25422789/95510853-6eccd380-096b-11eb-997e-2bdc04eca734.png">
<img width="751" alt="Screen Shot 2020-10-08 at 1 27 26 PM" src="https://user-images.githubusercontent.com/25422789/95510888-7d1aef80-096b-11eb-9335-a0bbd6eb72dc.png">
