### PR TITLE
Updated bar graph to format to window size

### DIFF
--- a/src/app/components/StateGraph/Visualizer.tsx
+++ b/src/app/components/StateGraph/Visualizer.tsx
@@ -76,11 +76,13 @@ const Visualizer: React.FC<VisualizerProps> = ({componentAtomTree}: any) => {
 
   const svgRef = useRef();
   useEffect(() => {
+    const widthx = document.querySelector('.Visualizer').clientWidth;
+    // let heightx = document.querySelector('.Visualizer').clientHeight;
     document.getElementById('canvas').innerHTML = '';
     // set the dimensions and margins of the graph
     const margin = {top: 20, right: 20, bottom: 30, left: 80},
-        width = 500 - margin.left - margin.right,
-        height = 300 - margin.top - margin.bottom;
+        width = widthx - margin.left - margin.right,
+        height = 340 - margin.top - margin.bottom;
     // set range for y scale
     const y = d3.scaleBand()
       .range([height, 0])
@@ -92,13 +94,17 @@ const Visualizer: React.FC<VisualizerProps> = ({componentAtomTree}: any) => {
     // append a 'group' element to 'svg'
     // moves the 'group' element to the top left margin
     const svg = d3.select(svgRef.current)
-      .attr("width", width + margin.left + margin.right)
-      .attr("height", height + margin.top + margin.bottom)
+      .classed("svg-container", true)
+      .append('svg')
+      .attr('class', 'chart')
+      .attr("viewBox", "0 0 600 490")
+      .attr("preserveAspectRatio", "xMinYMin meet")
+      .classed("svg-content-responsive", true)
       .append("g")
       .attr("transform", 
             "translate(" + margin.left + "," + margin.top + ")");
     // Scale the range of the data in the domains
-    x.domain([0, d3.max(data, function(d: any){ return d.actualDuration; })])
+    x.domain([0, d3.max(data, function(d: any){ return d.actualDuration; }) + 0.2])
     // Scale the range of he data across the y-axis
     y.domain(data.map(function(d: any) { return d.name; }));
     // append the rectangles for the bar chart

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -128,10 +128,6 @@ body {
   height: 100%;
   width: 100%;
 }
-.bar { 
-  fill: #9580ff; 
-}
-
 /* NAVBAR COMPONENT */
 .NavBar {
   width: 100%;
@@ -196,11 +192,28 @@ body {
 #canvas {
   height: 100%;
   width: 100%;
+  overflow: hidden;
 }
-
 #stateGraphContainer {
   height: calc(100% - 33px); /* 33px is height of navbar */
   width: 100%;
+}
+.bar { 
+  fill: #9580ff; 
+}
+.svg-container {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  padding-bottom: 50%; /* aspect ratio */
+  vertical-align: top;
+  overflow: hidden;
+}
+.svg-content-responsive {
+  display: inline-block;
+  position: absolute;
+  top: 10px;
+  left: 0;
 }
 
 /* NETWORK COMPONENT */


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Graph was not resizing to fit window.
## Approach
The graph is now changing relative to the window size.
## Screenshot(s)
![Screen Shot 2020-10-08 at 1 56 58 PM](https://user-images.githubusercontent.com/51557293/95512750-29f66c00-096e-11eb-9627-ab5239716951.png)
![Screen Shot 2020-10-07 at 6 52 42 PM](https://user-images.githubusercontent.com/51557293/95512793-367ac480-096e-11eb-929c-537c8f1c7f6d.png)
