### PR TITLE
Updated graph toggle from a switch to more descriptive buttons

### DIFF
--- a/src/app/components/StateGraph/Metrics.tsx
+++ b/src/app/components/StateGraph/Metrics.tsx
@@ -82,8 +82,8 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
     return x + y;
   }
 
-  const toggleGraphFunc = (flame:boolean): void => {
-    flame ? setGraphType(false) : setGraphType(true);
+  const toggleGraphFunc = (ranked:boolean): void => {
+    ranked ? setGraphType(false) : setGraphType(true);
   };
 
   const determineRender: any = () => {
@@ -142,14 +142,14 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
         <button
           className="timeTravelButton"
           onClick={() => {
-            toggleGraphFunc(true);
+            toggleGraphFunc(false);
           }}>
           Flame Graph
         </button>
         <button
           className="timeTravelButton"
           onClick={() => {
-            toggleGraphFunc(false);
+            toggleGraphFunc(true);
           }}>
           Ranked Graph
         </button>

--- a/src/app/components/StateGraph/Metrics.tsx
+++ b/src/app/components/StateGraph/Metrics.tsx
@@ -78,14 +78,13 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
 
   const cleanedTree: any = cleanComponentAtomTree(componentAtomTree);
 
-  const toggleGraphFunc = (): void => {
-    graphType ? setGraphType(false) : setGraphType(true);
-  };
-
-
   let sum = (x: number, y: number): number => {
     return x + y;
   }
+
+  const toggleGraphFunc = (flame:boolean): void => {
+    flame ? setGraphType(false) : setGraphType(true);
+  };
 
   const determineRender: any = () => {
     if(graphType){
@@ -105,6 +104,18 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
       );
     }
   }
+  // const determineText: any = () => {
+  //   if(graphType){
+  //     return(
+  //       <div>"Displaying render times of components + children"</div>
+  //     );
+  //   }
+  //   else{
+  //     return(
+  //       <div>"Displaying render times of individual components"</div>
+  //     );
+  //   }
+  // }
 
   const graph: any = determineRender();
 
@@ -118,7 +129,7 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
   return (
     <div>
       <div className="persistContainer">
-        <label className="switch" htmlFor="checkbox">
+        {/* <label className="switch" htmlFor="checkbox">
           <input
             data-testid="stateSettingsToggle"
             id="checkbox"
@@ -127,9 +138,23 @@ const Metrics: React.FC<MetricsProps> = ({componentAtomTree}) => {
             onChange={toggleGraphFunc}></input>
           <div className="slider round" />{' '}
         </label>
-        <span className="persistText">Slide to Toggle Graph Type</span>
+        <span className="persistText">Toggle Graph Type</span> */}
+        <button
+          className="timeTravelButton"
+          onClick={() => {
+            toggleGraphFunc(true);
+          }}>
+          Flame Graph
+        </button>
+        <button
+          className="timeTravelButton"
+          onClick={() => {
+            toggleGraphFunc(false);
+          }}>
+          Ranked Graph
+        </button>
       </div>
-      {graph}
+      {determineRender()}
     </div>
   );
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Previously a switch was used to jump between the ranked graph and the icicle graph in the metrics tab. But this didn't describe at all what each graph was or its purpose.
## Approach
<!--- How does your change address the problem? -->
Removed the switch and added 2 buttons that describe the graph displayed when clicked.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Read about flame graphs and ranked graphs to ensure that these were the correct names for the graphs based on the data that they describe.
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Screen Shot 2020-10-09 at 1 08 12 PM](https://user-images.githubusercontent.com/68144569/95627140-81f5a700-0a30-11eb-9fc1-75abf2b8655b.png)