### PR TITLE
Added conditional rendering for the suspense legend icon.

### DIFF
--- a/src/app/components/ComponentGraph/AtomComponentVisual.tsx
+++ b/src/app/components/ComponentGraph/AtomComponentVisual.tsx
@@ -88,14 +88,12 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
   useEffect(() => {
     height = document.querySelector('.Component').clientHeight;
     width = document.querySelector('.Component').clientWidth;
-    // Set the hasSuspense hook to false
-    // If there is a suspense component, this will be set to true in colorComponents function
-    // setHasSuspense(false);
+  
     document.getElementById('canvas').innerHTML = '';
 
     // reset hasSuspense to false. This will get updated to true if the red borders are rendered on the component graph.
     setHasSuspense(false);
-    
+
     // creating the main svg container for d3 elements
     const svgContainer = d3.select('#canvas');
 

--- a/src/app/components/ComponentGraph/AtomComponentVisual.tsx
+++ b/src/app/components/ComponentGraph/AtomComponentVisual.tsx
@@ -33,7 +33,7 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
   const [rawToggle, setRawToggle] = useState<boolean>(false);
 
   // useState hook to update whether a suspense component will be shown on the component graph
-  // const [hasSuspense, setHasSuspense] = useState<boolean>(false);
+  const [hasSuspense, setHasSuspense] = useState<boolean>(false);
  
   // Recursive function that will run through componentatomtree, filter out unecessary nodes, and create the new object appropriately
   const cleanComponentAtomTree = (
@@ -93,6 +93,9 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
     // setHasSuspense(false);
     document.getElementById('canvas').innerHTML = '';
 
+    // reset hasSuspense to false. This will get updated to true if the red borders are rendered on the component graph.
+    setHasSuspense(false);
+    
     // creating the main svg container for d3 elements
     const svgContainer = d3.select('#canvas');
 
@@ -375,7 +378,7 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
       }
 
       function borderColor(d:any): string {
-        
+        if(d.data.wasSuspended) setHasSuspense(true);
         return d.data.wasSuspended ? '#FF0000' : 'none';
       }
 
@@ -434,8 +437,8 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
         <p>SELECTOR</p>
         <div className="bothLegend"></div>
         <p>BOTH</p>
-        <div className="suspenseLegend"></div>
-        <p>SUSPENSE</p>
+        <div className={hasSuspense ? "suspenseLegend" : ''}></div>
+        <p>{hasSuspense?'SUSPENSE': ''}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The component graph legend would always show the suspense key. It was decided to only show this if a suspense component was actually rendered on the component graph.
## Approach
<!--- How does your change address the problem? -->
Used ternary operators within the AtomComponentVisual returned divs that hold the legend keys. The conditional statement checks to see if a hasSuspense hook is true or false. If true a Suspense key is rendered in the legend.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Researched techniques for conditional rendering of div components. Ternary operators were the most efficient way for this situation. 
https://reactjs-bot.github.io/react/docs/lists-conditional-rendering.html