### PR TITLE
Provided metrics graph buttons with their own styling.

### DIFF
--- a/src/app/components/StateGraph/Metrics.tsx
+++ b/src/app/components/StateGraph/Metrics.tsx
@@ -55,16 +55,17 @@ const Metrics: React.FC<MetricsProps> = ({cleanedComponentAtomTree}) => {
 
   return (
     <div>
-      <div className="persistContainer">
+      <div className="graphContainer">
         <button
-          className="timeTravelButton"
+          className="graphButton"
+          autoFocus={true}
           onClick={() => {
             toggleGraphFunc(false);
           }}>
           Flame Graph
         </button>
         <button
-          className="timeTravelButton"
+          className="graphButton"
           onClick={() => {
             toggleGraphFunc(true);
           }}>

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -220,6 +220,30 @@ body {
   left: 0;
 }
 
+.graphContainer {
+  padding: 10px;
+}
+
+.graphButton {
+  border: 1px solid #989898;
+  border-radius: 5px;
+  color: #989898;
+  background: none;
+  outline: none;
+}
+
+.graphButton:hover{
+  color: #e6e6e6;
+  border: 1px solid white;
+  background-color: #212121;
+  text-emphasis: bold;
+}
+
+.graphButton:focus {
+  color: #e6e6e6;
+  background-color: #212121;
+}
+
 /* NETWORK COMPONENT */
 .networkContainer {
   height: 100%;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
- The metrics graph buttons were utilizing the same styling as time travel buttons, thus changes to either would affect both.
- The metrics graph buttons were not properly spaced.
- The neither metrics graph button was in focus on page load.
## Approach
<!--- How does your change address the problem? -->
- Changed class names of metrics graph buttons and container, and provided those classes with own css styling.
- Added autoFocus attribute to the flamegraph button
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
Updated Buttons
![Screen Shot 2020-10-14 at 11 42 32 AM](https://user-images.githubusercontent.com/68144569/96031592-6c0e2a80-0e12-11eb-9b1e-b8195c27b611.png)
Buttons Prior to Update
![Screen Shot 2020-10-14 at 11 22 28 AM](https://user-images.githubusercontent.com/68144569/96031625-74666580-0e12-11eb-96d7-3d48405d66d7.png)
