### PR TITLE
Added more tests for the SnapshotList component.

### DIFF
--- a/src/app/components/SnapshotList/__tests__/SnapshotList.unit.test.js
+++ b/src/app/components/SnapshotList/__tests__/SnapshotList.unit.test.js
@@ -1,58 +1,103 @@
 import React, {useState} from 'react';
 import {configure, shallow} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import ReactDOM from 'react-dom';
-import {getQueriesForElement, getByText} from '@testing-library/dom';
-
-import {render, fireEvent} from '@testing-library/react';
 
 import SnapshotsList from '../SnapshotList';
 
 // Newer enzyme versions require this configuration to adapt to a particular version of React
 configure({ adapter: new Adapter() });
 
-it('Checks if SnapshotList Renders', () => {
-  window.HTMLElement.prototype.scrollIntoView = jest.fn();
-  const {getByPlaceholderText, debug} = render(
-    <SnapshotsList snapshotHistory={[]} />,
-  );
-});
-
-// Test to see if invalid props break the function. Functional component should render empty div when props are invalid.
-describe('Snapshots List Error Handling', () => {
+describe('Testing for rendering of SnapshotList under several expected conditions', () => {
   let wrapper;
-  const props = {
-    renderIndex: 0,
-    snapshotHistoryLength: 1,
-    setRenderIndex: jest.fn(),
-    timeTravelFunc: jest.fn(),
-    selected: [{name: "id"}],
-    filter: [],
-    snapshotHistory: [{
-      componentAtomTree: {
-        actualDuration: 12,
-        children: [],
-        name: 'HR',
-        recoilNodes: [],
-        tag: 3,
-        treeBaseDuration: 6,
-        wasSuspended: false,
-      },
-      filteredSnapshot: {
-        id: {
-          contents: 1,
-          nodeDeps: [],
-          nodeToNodeSubscriptions: [],
-          type: "RecoilState",
+  let childObj;
+  let props;
+  beforeEach(() => {
+
+    childObj = {
+      actualDuration: 14,
+      children: [],
+      name: 'Replace',
+      recoildNodes: [],
+      tag: 0,
+      treeBaseDuration: 6,
+      wasSuspended: false,
+    }
+
+    props = {
+      renderIndex: 0,
+      snapshotHistoryLength: 1,
+      setRenderIndex: jest.fn(),
+      timeTravelFunc: jest.fn(),
+      selected: [{name: "id"}],
+      filter: [],
+      snapshotHistory: [{
+        componentAtomTree: {
+          actualDuration: 12,
+          children: [{
+            ...childObj, 
+            name: 'RecoilRoot', 
+            childdren: [{
+              ...childObj, 
+              tag: 10, 
+              children: [{...childObj }] 
+            }]
+          }],
+          name: 'HR',
+          recoilNodes: [],
+          tag: 3,
+          treeBaseDuration: 6,
+          wasSuspended: false,
+        },
+        filteredSnapshot: {
+          id: {
+            contents: 1,
+            nodeDeps: [],
+            nodeToNodeSubscriptions: [],
+            type: "RecoilState",
+          }
         }
-      }
-    }],
-  }
+      }],
+    }
+  })
 
-  it('Snapshots List renders empty divs when props are invalid.', () => {
-
-    wrapper = shallow(<SnapshotsList {...props}  />);
+  it('Renders with no componentAtomTree children', () => {
+    props.snapshotHistory[0].componentAtomTree.children = [];
+    wrapper = shallow(<SnapshotsList {...props} />);
     expect(wrapper.type()).toEqual('div');
+    expect(wrapper.find('div').first().hasClass('SnapshotsList')).toEqual(true);
+  })
+
+  it('Renders one div with class individualSnapshot when filter is empty', () => {
+    wrapper = shallow(<SnapshotsList {...props} />);
+    let individual = 0;
+    for (let key of wrapper.find('div')){
+      if (key.props) {
+        if(key.props.className){
+          if(key.props.className === 'individualSnapshot') individual += 1;
+        };
+      };
+    };
+    expect(individual).toBe(1);
+  })
+
+  // Test to see if invalid props break the function. Functional component should render empty div when props are invalid.
+  describe('Snapshots List Error Handling', () => {
+    
+    it('Snapshots List renders empty divs when renderIndex is invalid', () => {
+      props.renderIndex = -1;
+      wrapper = shallow(<SnapshotsList {...props}  />);
+      expect(wrapper.type()).toEqual('div');
+      expect(wrapper.find('div').first().hasClass('SnapshotsList')).toEqual(true);
+    });
+
+    it('Handles the snapshotHistoryLength prop being greater than the filter length', () => {
+      props.snapshotHistoryLength = 8;
+      wrapper = shallow(<SnapshotsList {...props} />);
+      expect(wrapper.type()).toEqual('div');
+      expect(wrapper.find('div').first().hasClass('SnapshotsList')).toEqual(true);
+
+    } )
+
   });
 
 });


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Test coverage for the SnapshotList component did not check for individual render time divs being rendered.
## Approach
<!--- How does your change address the problem? -->
Leveraged jest enzyme built-in functionality to test the rendering of div elements containing the render times in the snapshotsList component. These div elements have class 'individualSnapshot' and so the hasClass function was used to return true whenever the class was found within a div container. 
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, add-ons, or other resources that helped you to solve this problem. -->
Reviewed Jest enzyme functions such as hasClass() to check whether a div element has a particular class and first() which returns the first element within the iterable object resulting from find().
https://enzymejs.github.io/enzyme/docs/api/ShallowWrapper/hasClass.html
https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/first.html