### PR TITLE
Fixed page refresh dev tool crash

### DIFF
--- a/src/app/Containers/MainContainer.tsx
+++ b/src/app/Containers/MainContainer.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 import SnapshotsContainer from './SnapshotContainer';
 import VisualContainer from './VisualContainer';
 import {stateSnapshot, selectedTypes, stateSnapshotDiff} from '../../types';
+import { render } from '@testing-library/react';
 
 interface MainContainerProps {
   // snapshotHistory is an array of stateSnapshots
@@ -27,7 +28,9 @@ const MainContainer: React.FC<MainContainerProps> = ({
 
   // useEffect for renderIndex
   useEffect(() => {
+
     setRenderIndex(snapshotHistory.length - 1);
+
   }, [snapshotHistory]);
 
   // render containers passing necessary props
@@ -49,7 +52,7 @@ const MainContainer: React.FC<MainContainerProps> = ({
         // snapshot at index [renderIndex -1]
         previousSnapshot={snapshotHistory[renderIndex - 1]}
         // snapshot at index [renderIndex]
-        currentSnapshot={snapshotHistory[renderIndex]}
+        currentSnapshot={(snapshotHistory[renderIndex]) ? snapshotHistory[renderIndex] : snapshotHistory[0]}
         // !passing through snapshotHistory
         snapshotHistory={snapshotHistory}
         // !passing through selections

--- a/src/app/Containers/MainContainer.tsx
+++ b/src/app/Containers/MainContainer.tsx
@@ -2,7 +2,6 @@ import React, {useState, useEffect} from 'react';
 import SnapshotsContainer from './SnapshotContainer';
 import VisualContainer from './VisualContainer';
 import {stateSnapshot, selectedTypes, stateSnapshotDiff} from '../../types';
-import { render } from '@testing-library/react';
 
 interface MainContainerProps {
   // snapshotHistory is an array of stateSnapshots

--- a/src/app/components/ComponentGraph/AtomComponentVisual.tsx
+++ b/src/app/components/ComponentGraph/AtomComponentVisual.tsx
@@ -63,7 +63,7 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
 
     // creating the tree map
     const treeMap = d3.tree().nodeSize([height, width]);
-
+ 
     if (!rawToggle) {
       root = d3.hierarchy(cleanedComponentAtomTree, function (
         d: componentAtomTree,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The Recoilize dev tool would crash while on the Component Graph tab or the Metrics tab but only if there had been state changes recorded. The purpose of this was to look into why the crash was occurring and fix the crash.
## Approach
<!--- How does your change address the problem? -->
The console error was flagging an undefined value with the hierarchy function used by d3. This function was invoked in AtomComponentVisual.tsx and it was noted that the data being passed in as a parameter was dependent on a react hooks state, renderIndex. 

The async behavior of setRenderIndex made it so that there was an instance where renderIndex was set to 0, but the previous value persisted for a moment while currentSnapshot was evaluated. This resulted in an undefined currentSnapshot. A ternary operator was utilized while defining currentSnapshot so that it could have a fallback value when using renderIndex resulted in undefined. 

## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
This served as a reminder that the React Hooks set state functionality is an asynchronous operation. Researched setting this async behavior to be synchronous, although ultimately this was not the chosen path.
https://sung.codes/blog/2018/12/07/setting-react-hooks-states-in-a-sync-like-manner/
