### PR TITLE
Added Duration based color scaling to Flamegraph

### DIFF
--- a/src/app/components/Metrics/FlameGraph.js
+++ b/src/app/components/Metrics/FlameGraph.js
@@ -53,9 +53,10 @@ const IcicleVertical = (props) => {
   // const color = scaleOrdinal(
   //   quantize(interpolateRainbow, root.children.length + 1)
   // );
+  console.log(averageDiration);
   const color = scaleLinear()
-  .domain([averageDiration/2, averageDiration, averageDiration * 2, averageDiration * 4, averageDiration * 6])
-  .range(["#ffffff","#e9c7ff", "#f95cb3", "#ee9f30", "red"])
+  .domain([averageDiration/2, averageDiration * 2, averageDiration * 3, averageDiration * 4, averageDiration * 5])
+  .range(["#ffffff","#e9c7ff", "#f95cb3", "#ee9f30", "#ff0000"])
   // const color = scaleLinear()
   // .domain([0, averageDiration, averageDiration * 2, averageDiration * 4, averageDiration * 6])
   // .range(["#4281A4","#9CAFB7", "#EAD2AC", "#E6B89C", "#FE938C" ])

--- a/src/app/components/Metrics/FlameGraph.js
+++ b/src/app/components/Metrics/FlameGraph.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
-import { scaleLinear, scaleOrdinal } from 'd3-scale';
+import * as d3 from 'd3';
+import { scaleLinear, scaleOrdinal, scaleSequential } from 'd3-scale';
 import { interpolate as d3interpolate, quantize } from 'd3-interpolate';
 import { interpolateRainbow } from 'd3-scale-chromatic';
 import { format as d3format } from 'd3-format';
@@ -34,11 +35,32 @@ const IcicleVertical = (props) => {
   .sum(d => d.actualDuration)
   .sort((a, b) => b.value - a.value);
 
+  let totalDuration = 0;
+  root.each(() => {
+    totalDuration = totalDuration + 1;
+    return;
+  });
+
+  // console.log("Number of components", total);
+  // console.log('Total time', root.value);
+  // console.log('Average time', root.value/total);
+
+  const averageDiration = root.value/totalDuration;
+
+
   const margin = { top: 0, left: 0, right: 0, bottom: 0 }
 
-  const color = scaleOrdinal(
-    quantize(interpolateRainbow, root.children.length + 1)
-  );
+  // const color = scaleOrdinal(
+  //   quantize(interpolateRainbow, root.children.length + 1)
+  // );
+  const color = scaleLinear()
+  .domain([averageDiration/2, averageDiration, averageDiration * 2, averageDiration * 4, averageDiration * 6])
+  .range(["#ffffff","#e9c7ff", "#f95cb3", "#ee9f30", "red"])
+  // const color = scaleLinear()
+  // .domain([0, averageDiration, averageDiration * 2, averageDiration * 4, averageDiration * 6])
+  // .range(["#4281A4","#9CAFB7", "#EAD2AC", "#E6B89C", "#FE938C" ])
+  // var color = scaleSequential(d3.interpolateBlues)
+  //   .domain([0, averageDiration * 5])
 
   const [state, setState] = useState({
     xDomain: [0, props.width],
@@ -93,9 +115,6 @@ const IcicleVertical = (props) => {
           <Group>
             {data.descendants().map((node, i) => (
               <animated.g
-                // top={yScale.current(node.y0)}
-                // left={xScale.current(node.x0)}
-                //transform={`translate(${xScale.current(node.x0)}, ${yScale.current(node.y0)})`}
                 transform={t.interpolate(
                   () =>
                     `translate(${xScale.current(node.y0)}, ${yScale.current(
@@ -135,11 +154,13 @@ const IcicleVertical = (props) => {
                     () => yScale.current(node.x1) - yScale.current(node.x0)
                   )}
                   fill={
-                    node.children
-                      ? '#ddd'
-                      : color(node.data.id.split('.').slice(0, 2))
+                    // node.children
+                    //   ? '#ddd'
+                    //   : color(node.data.id.split('.').slice(0, 2))
+                    // node.data.actualDuration > 2 ? '#ddd' : '#A51CA4'
+                    color(node.data.actualDuration)
                   }
-                  fillOpacity={node.children ? 1 : 0.6}
+                  fillOpacity={1}
                 />
 
                 <clipPath id={`clip-${i}`}>


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
- Prior to the change the flame graph didn't utilize color to display the data. The leaf nodes were colored and the rest of the graph was grey. This did nothing to help the user understand the data better.
## Approach
<!--- How does your change address the problem? -->
- Utilized d3.interpolate to scale the color of each d3 node based on the actual duration of its corresponding component. To do this a function was introduced which calculated the average actualDuration of the entire tree and then the color was scaled based on component actualDuration relative to average actualDuration.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
- Learned that there are many other uses for d3.interpolate, both with regard to colors and scaling of many other kinds.
https://bl.ocks.org/EfratVil/903d82a7cde553fb6739fe55af6103e2
https://github.com/d3/d3-interpolate
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
Updated graph with color
![Screen Shot 2020-10-15 at 7 04 08 PM](https://user-images.githubusercontent.com/68144569/96206176-343fd980-0f1d-11eb-9995-b2166e6d27c6.png)
Visual of gradient introduced 
White: 1/2AD, Purple: 2AD, Pink: 3AD, Yellow: 4AD, Red: 5AD (averageDuration = AD)
![Screen Shot 2020-10-15 at 7 19 25 PM](https://user-images.githubusercontent.com/68144569/96206337-87199100-0f1d-11eb-92a4-62427b52b9be.png)
