### PR TITLE
Included missing graph component names

### DIFF
--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -63,6 +63,10 @@ const createAtomsSelectorArray = node => {
 
 // keep an eye on this section as we test bigger and bigger applications SEAN
 const assignName = node => {
+  // Returns symbol key if $$typeof is defined. Some components, such as context providers, will have this value.
+  if(node.type && node.type.$$typeof) return Symbol.keyFor(node.type.$$typeof);
+  // Return suspense if tag is equal to 13, which is associated with Suspense components. 
+  if(node.tag === 13) return 'Suspense';
   // Find name of a class component
   if (node.type && node.type.name) return node.type.name;
   // Tag 5 === HostComponent

--- a/package/formatFiberNodes.ts
+++ b/package/formatFiberNodes.ts
@@ -85,6 +85,10 @@ const createAtomsSelectorArray = (node: any) => {
 
 // keep an eye on this section as we test bigger and bigger applications
 const assignName = (node: any) => {
+  // Returns symbol key if $$typeof is defined. Some components, such as context providers, will have this value.
+  if(node.type && node.type.$$typeof) return Symbol.keyFor(node.type.$$typeof);
+  // Return suspense if tag is equal to 13, which is associated with Suspense components. 
+  if(node.tag === 13) return 'Suspense';
   // Find name of a class component
   if (node.type && node.type.name) return node.type.name;
   // Tag 5 === HostComponent


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The expanded component graph tree contained some nodes without any labels. This is because the name property had not been saved for  several components such as suspense components and context provider components. 
## Approach
<!--- How does your change address the problem? -->
Updated the assignName function within formatFiberNodes to include a conditional return if the tag is equal to 13 (meaning that it is a suspense component) and a conditional return if the type key has a key of $$typeof. It was noted that some nodes that do not have a type.name property have a type.$$typeof property which holds a symbol with a component type key.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Read into the purpose of having $$typeof and then researched how to extract a key from a javascript symbol object.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
https://overreacted.io/why-do-react-elements-have-typeof-property/
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
<img width="398" alt="Screen Shot 2020-10-15 at 4 41 20 PM" src="https://user-images.githubusercontent.com/25422789/96217456-79710500-0f37-11eb-878b-d04be4625fc8.png">
<img width="398" alt="Screen Shot 2020-10-15 at 5 01 32 PM" src="https://user-images.githubusercontent.com/25422789/96217467-7e35b900-0f37-11eb-807c-9a993b793812.png">

