### PR TITLE
Added zoom and drag functionality to Ranked Graph

### DIFF
--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -57,9 +57,9 @@ const createAtomsSelectorArray = node => {
 // keep an eye on this section as we test bigger and bigger applications SEAN
 const assignName = node => {
   // Returns symbol key if $$typeof is defined. Some components, such as context providers, will have this value.
-  if(node.type && node.type.$$typeof) return Symbol.keyFor(node.type.$$typeof);
-  // Return suspense if tag is equal to 13, which is associated with Suspense components. 
-  if(node.tag === 13) return 'Suspense';
+  if (node.type && node.type.$$typeof) return Symbol.keyFor(node.type.$$typeof);
+  // Return suspense if tag is equal to 13, which is associated with Suspense components.
+  if (node.tag === 13) return 'Suspense';
   // Find name of a class component
   if (node.type && node.type.name) return node.type.name;
   // Tag 5 === HostComponent

--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -51,6 +51,9 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
       .attr("viewBox", "0 0 600 490")
       .attr("preserveAspectRatio", "xMinYMin meet")
       .classed("svg-content-responsive", true)
+      .call(d3.zoom().on("zoom", function () {
+        svg.attr("transform", d3.event.transform)
+     }))
       .append("g")
       .attr("transform", 
             "translate(" + margin.left + "," + margin.top + ")")


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
There was no zoom feature or dragging ability in the ranked graph. The user would not be able to take a closer look at the render times and components names.
## Approach
Added zoom and dragging functionality so that the user can resize and move the graph around.
## Learning
https://www.d3-graph-gallery.com/graph/interactivity_zoom.html