### PR TITLE
Included intermediate components in the visualizations

### DIFF
--- a/src/app/Containers/VisualContainer.tsx
+++ b/src/app/Containers/VisualContainer.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import Diff from '../components/StateDiff/Diff';
 import NavBar from '../components/NavBar/NavBar';
 import Metrics from '../components/Metrics/MetricsContainer';
@@ -35,7 +35,7 @@ const cleanComponentAtomTree = (inputObj: componentAtomTree): componentAtomTree 
   let counter = 0;
   const innerClean = (inputObj: any, outputObj: any, counter: number = 0) => {
     if (
-      inputObj.tag === 0 &&
+      (inputObj.tag === 0 || inputObj.tag === 2) &&
       inputObj.name !== 'RecoilRoot' &&
       inputObj.name !== 'Batcher' &&
       inputObj.name !== 'RecoilizeDebugger' &&
@@ -113,7 +113,6 @@ const VisualContainer: React.FC<VisualContainerProps> = ({
   const cleanedComponentAtomTree = currentSnapshot
     ? cleanComponentAtomTree(currentSnapshot.componentAtomTree)
     : undefined;
-
 
   // object containing all conditional renders based on navBar
   const nav: navTypes = {

--- a/src/app/Containers/VisualContainer.tsx
+++ b/src/app/Containers/VisualContainer.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import Diff from '../components/StateDiff/Diff';
 import NavBar from '../components/NavBar/NavBar';
 import Metrics from '../components/Metrics/MetricsContainer';


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The initial component visuals were not including all of the functional components if they were suspended initially. 
## Approach
<!--- How does your change address the problem? -->
Reviewed the fiber tree used by the backend to create the first snapshot. It was noted that the suspended components have tags of 2 which signifies an IndeterminateComponent. I included this tag to the cleanedComponent function which initially only selected nodes with a tag of 0.
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
<img width="698" alt="Screen Shot 2020-10-16 at 3 31 28 PM" src="https://user-images.githubusercontent.com/25422789/96329463-f4065700-1001-11eb-9339-5e6155e1d18d.png">
<img width="908" alt="Screen Shot 2020-10-16 at 4 31 15 PM" src="https://user-images.githubusercontent.com/25422789/96329470-02547300-1002-11eb-9176-a15c61ec26d2.png">
