### PR TITLE
Updated colors on ranked graph

### DIFF
--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -42,9 +42,9 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
       .padding(0.2)
     // determines the color based on actualDuration
     function colorPicker(data: any) {
-      if(data <= 1 ) return '#4dd2ff';
-      else if(data <= 2) return '#00ace6'
-      else return '#006080';
+      if(data <= 1 ) return '#51a8f0';
+      else if(data <= 2) return '#3a7bb0'
+      else return '#2d608a';
     }
     // append the svg object to the body of the page
     // append a 'group' element to 'svg'

--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -6,7 +6,6 @@ interface RankedGraphProps {
   cleanedComponentAtomTree: componentAtomTree;
 }
 
-
 const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any) => {
   // create an empty array to store objects for property name and actualDuration
   const data: {}[] = [];
@@ -41,6 +40,12 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
     const z = d3.scaleBand()
       .range([height,0])
       .padding(0.2)
+    // determines the color based on actualDuration
+    function colorPicker(data: any) {
+      if(data <= 1 ) return '#4dd2ff';
+      else if(data <= 2) return '#00ace6'
+      else return '#006080';
+    }
     // append the svg object to the body of the page
     // append a 'group' element to 'svg'
     // moves the 'group' element to the top left margin
@@ -57,7 +62,7 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
       .append("g")
       .attr("transform", 
             "translate(" + margin.left + "," + margin.top + ")")
-    // Scale the range of the data in the domains
+    // Scale the range of the data in the domain
     x.domain([0, d3.max(data, (d: any) => {
        return d.actualDuration; 
       })])
@@ -100,9 +105,8 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
       .duration(750)
       .delay((d: any,i: any) => i * 100)
       .attr("width", function(d: any) {return x(d.actualDuration); } )
-      .attr("fill", function(d:any) {
-        // return "rgb("+ Math.round(d.actualDuration * 120) + ",0," + Math.round(d.actualDuration * 10) + ")";
-        return "rgb("+ "0" + "," + Math.round(d.actualDuration * 130) + "," + Math.round(d.actualDuration * 170) + ")";
+      .attr('fill',function(d:any) {
+        return colorPicker(d.actualDuration)
       })
       .attr("y", function(d: any, i: any) { return y(d.name + '-' + i)})
       .attr("height", y.bandwidth());


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The ranked graph was displaying the shorter durations to be a darker color than the longer durations. The darker color was also making it difficult to see the individual bar.
## Approach
<!--- How does your change address the problem? -->
It makes more sense for the shorter durations to display a lighter shade and the longer durations to display a darker shade. 
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Screen Shot 2020-10-20 at 3 06 43 PM](https://user-images.githubusercontent.com/51557293/96649399-e42e9180-12e5-11eb-9f8d-72022922a5c8.png)
