### PR TITLE
Adjusted width setting of Ranked Graph

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -136,9 +136,6 @@ export default function RecoilizeDebugger(props) {
       case 'throttleEdit':
         throttleLimit = parseInt(msg.data.payload.value);
         break;
-      // Hover effect payload handling
-      case 'mouseover':
-        let hoverComponent = 
       default:
         break;
     }

--- a/src/app/Containers/SnapshotContainer.tsx
+++ b/src/app/Containers/SnapshotContainer.tsx
@@ -38,7 +38,9 @@ const SnapshotsContainer: React.FC<SnapshotsContainerProps> = ({
     backgroundConnection.postMessage({
       action: 'snapshotTimeTravel',
       tabId: chrome.devtools.inspectedWindow.tabId,
-      payload: {snapshotIndex: index + indexDiff},
+      payload: {
+        snapshotIndex: index + indexDiff,
+      },
     });
   };
   return (

--- a/src/app/components/Metrics/MetricsContainer.tsx
+++ b/src/app/components/Metrics/MetricsContainer.tsx
@@ -34,14 +34,20 @@ const Metrics: React.FC<MetricsProps> = ({cleanedComponentAtomTree}) => {
     }
     else{
       return(
-        <RankedGraph cleanedComponentAtomTree={cleanedComponentAtomTree}/>
+        <ParentSize>
+          {size =>
+            size.ref &&
+            <RankedGraph cleanedComponentAtomTree={cleanedComponentAtomTree} width={size.width} height={size.height}/>
+          }
+        </ParentSize>
+        
       );
     }
   }
   
   //render the toggle buttons and the appropriate graph based on GraphType state variable
   return (
-    <div>
+    <div id="metricsWrapper">
       <div data-testid="canvas" className="graphContainer">
         <button
           className="graphButton"

--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -31,8 +31,6 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree, widt
 
   const svgRef = useRef();
   useEffect(() => {
-    // const width = document.querySelector('.RankedGraph').clientWidth;
-    // const height = 375;
     document.getElementById('canvas').innerHTML = '';
     // set the dimensions and margins of the graph
     let left = 80;
@@ -136,7 +134,9 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree, widt
   },[data]);
   
   return (
-    <svg id='canvas' ref={svgRef}></svg>
+    <div data-testid='canvas' id='stateGraphContainer'>
+      <svg id='canvas' ref={svgRef}></svg>
+    </div>
   );
 };
 

--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -79,9 +79,10 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
         const barName = 'hello from barName';
         const payload = {
           action: "mouseover",
+          tabId: chrome.devtools.inspectedWindow.tabId,
           payload: barName
         }
-        backgroundConnection.postMessage(payload)
+        backgroundConnection.postMessage(payload);
       })
       .on("mouseout", function(){
         d3.select(this).attr('opacity', '1');
@@ -89,6 +90,7 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
         let barName = this.name;
         const payload = {
           action: "mouseout",
+          tabId: chrome.devtools.inspectedWindow.tabId,
           payload: barName
         }
         backgroundConnection.postMessage(payload)
@@ -127,3 +129,10 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
 };
 
 export default RankedGraph;
+
+
+chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+  chrome.tabs.sendMessage(tabs[0].id, {greeting: "hello"}, function(response) {
+    console.log(response.farewell);
+  });
+});

--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -3,18 +3,24 @@ import * as d3 from 'd3';
 import {componentAtomTree} from '../../../types';
 
 interface RankedGraphProps {
-  cleanedComponentAtomTree: componentAtomTree;
+  cleanedComponentAtomTree: componentAtomTree,
+  width?: number,
+  height?: number, 
 }
 
 
-const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any) => {
+const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree, width, height}: RankedGraphProps) => {
   // create an empty array to store objects for property name and actualDuration
   const data: {}[] = [];
+  let length = 0;
   // function to traverse through the fiber tree
   const namesAndDurations = (node: any) => {
     if (node === undefined) return;
     if (node.name && node.actualDuration) {
       const obj: any = {}
+      if(node.name.length > length){
+        length = node.name.length;
+      }
       obj["name"] = node.name;
       obj["actualDuration"] = node.actualDuration;
       data.push(obj)
@@ -25,11 +31,19 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
 
   const svgRef = useRef();
   useEffect(() => {
-    const width = document.querySelector('.RankedGraph').clientWidth;
-    const height = 375;
+    // const width = document.querySelector('.RankedGraph').clientWidth;
+    // const height = 375;
     document.getElementById('canvas').innerHTML = '';
     // set the dimensions and margins of the graph
-    const margin = {top: 20, right: 20, bottom: 30, left: 80}
+    let left = 80;
+    if(length > 13){
+      left = 100;
+    }
+    if(length > 17){
+      left = 120;
+    }
+    
+    const margin = {top: 20, right: 20, bottom: 30, left}
     // set range for y scale 
     const y = d3.scaleBand()
       .range([height, 0])
@@ -77,7 +91,6 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
       .attr("class", "bar")
       .on("mouseover", function() {
         d3.select(this).attr('opacity', '0.85');
-        console.log('in the ranked graph function')
         const backgroundConnection = chrome.runtime.connect();
         const barName = 'hello from barName';
         const payload = {
@@ -123,19 +136,8 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree}: any
   },[data]);
   
   return (
-    <div data-testid='canvas' id='stateGraphContainer'>
-      <div className='RankedGraph'>
-        <svg id='canvas' ref={svgRef}></svg>
-      </div>
-    </div>
+    <svg id='canvas' ref={svgRef}></svg>
   );
 };
 
 export default RankedGraph;
-
-
-chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-  chrome.tabs.sendMessage(tabs[0].id, {greeting: "hello"}, function(response) {
-    console.log(response.farewell);
-  });
-});

--- a/src/app/components/Metrics/RankedGraph.tsx
+++ b/src/app/components/Metrics/RankedGraph.tsx
@@ -44,11 +44,11 @@ const RankedGraph: React.FC<RankedGraphProps> = ({cleanedComponentAtomTree, widt
     const margin = {top: 20, right: 20, bottom: 30, left}
     // set range for y scale 
     const y = d3.scaleBand()
-      .range([height, 0])
+      .range([(height), 0])
       .padding(0.2);
     // set range for x scale
     const x = d3.scaleLinear()
-      .range([0, width]);  
+      .range([0, (width * 0.8)]);  
     // set range for durations      
     const z = d3.scaleBand()
       .range([height,0])

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -3,6 +3,7 @@ interface Msg {
   action: string;
   tabId?: string;
   payload?: object;
+  test?: number;
 }
 
 interface Connections {
@@ -39,6 +40,12 @@ chrome.runtime.onConnect.addListener(port => {
       case 'snapshotTimeTravel':
         if (tabId) {
           // if msg tabId provided, send time travel snapshot history to content-script
+          chrome.tabs.sendMessage(Number(tabId), msg);
+        }
+        break;
+      
+      case 'mouseover':
+        if(tabId) {
           chrome.tabs.sendMessage(Number(tabId), msg);
         }
         break;

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -192,9 +192,14 @@ body {
 }
 
 /* VISUALIZER COMPONENT  */
+#metricsWrapper {
+  height: calc(100% - 33px);
+  width: 100%;
+}
+
 .RankedGraph,
 #canvas {
-  height: 100%;
+  flex-grow: 1;
   width: 100%;
   overflow: hidden;
 }
@@ -209,7 +214,7 @@ body {
   display: inline-block;
   position: relative;
   width: 100%;
-  padding-bottom: 50%; /* aspect ratio */
+  /* padding-bottom: 50%; aspect ratio */
   vertical-align: top;
   overflow: hidden;
 }

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -21,7 +21,7 @@ chrome.runtime.onMessage.addListener(msg => {
       window.postMessage(msg, '*');
       break;
     case 'mouseover':
-      window.console.log('msg received content script')
+      console.log('MSG received content script')
       window.postMessage(msg, '*')
       break;
   }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
There were problems with the way the ranked graph scaled to the window, and when y-axis labels were too long the text would spill out of the window.
## Approach
<!--- How does your change address the problem? -->
Utilized <parentSize> from the vx library to set the width and height of the svg, adjusted css styling of related elements, and added code to adjust the left margin based on the longest string of the y-axis labels. 
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
-Better understanding of the vx library and its features beyond parentSize
https://vx-demo.now.sh/docs/responsive
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Screen Shot 2020-10-20 at 7 53 06 PM](https://user-images.githubusercontent.com/68144569/96667455-f4f2fd80-130d-11eb-9b48-96ab35919ba8.png)
![Screen Shot 2020-10-20 at 7 53 27 PM](https://user-images.githubusercontent.com/68144569/96667486-ff14fc00-130d-11eb-9cc3-77d3e52b7886.png)
