### PR TITLE
Added a recoilizeRoot variable to store the root.

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -24,11 +24,15 @@ export default function RecoilizeDebugger(props) {
   // We should ask for Array of atoms and selectors.
   // Captures all atoms that were defined to get the initial state
 
+  // Define a recoilizeRoot variable which will be assigned based on whether a root is passed in as a prop
+  let recoilizeRoot;
+
   // Check if a root was passed to props.
   if (props.root) {
     const {root} = props;
+    recoilizeRoot = root;
   } else {
-    const root = document.getElementById('root');
+    recoilizeRoot = document.getElementById('root');
   }
 
   const snapshot = useRecoilSnapshot();
@@ -181,7 +185,7 @@ export default function RecoilizeDebugger(props) {
       return {
         filteredSnapshot: filteredSnapshot,
         componentAtomTree: formatFiberNodes(
-          root._reactRootContainer._internalRoot.current,
+          recoilizeRoot._reactRootContainer._internalRoot.current,
         ),
       };
     } else {
@@ -189,7 +193,7 @@ export default function RecoilizeDebugger(props) {
       return {
         filteredSnapshot: filteredSnapshot,
         componentAtomTree: formatFiberNodes(
-          root._reactRootContainer._internalRoot.current,
+          recoilizeRoot._reactRootContainer._internalRoot.current,
         ),
         indexDiff: diff,
       };


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The components and state being shown were always from the entire react fiber tree starting at id of 'root'. This was the case even when the user specified a different root.
## Approach
<!--- How does your change address the problem? -->
Created a variable called recoilizeRoot to store the root. This was assigned a proper root inside a conditional statement.

Previously the variable, root, was being used but declarations occurred inside a conditional statement. This variable did not persist outside of the condition so when the variable 'root' was used downstream in the code javascript was interpreting it as document.getElementById('root'). This made it so that the react fiber tree would always start at id of 'root'.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Within the context of the DOM, root is defined as document.getElementById('root'). A different variable name was used to avoid uncaught errors. 
