### PR TITLE
(Fix) Component Graph Colorizing for Recoil 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
       "jest-webextension-mock"
     ]
   },
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "A Chrome extension that helps debug Recoil applications by memorizing the state of components with every render.",
   "main": "index.js",
   "scripts": {

--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -32,25 +32,32 @@ const createAtomsSelectorArray = node => {
 
   // Traverse through the memoizedStates and look for the deps key which holds selectors or state.
   while (currentNode) {
-    // if the memoizedState has a deps key, and that deps key is an array of length 2 then the first value of that array will be an atom or selector
+    // if the memoizedState has a deps key, and that deps key is an array
+    // then the first value of that array will be an atom or selector
     if (
-      currentNode.deps &&
-      Array.isArray(currentNode.deps) &&
-      currentNode.deps.length === 2
+      currentNode.hasOwnProperty('memoizedState') &&
+      typeof currentNode.memoizedState === 'object' &&
+      !Array.isArray(currentNode.memoizedState) &&
+      currentNode.memoizedState.hasOwnProperty('deps')
     ) {
-      // if the atom/selector already exist in the recoilNodes array then break from this while loop. At this point you are traversing through previous atom/selector deps.
-      if (recoilNodes.includes(currentNode.deps[0].key)) break;
-      recoilNodes.push(currentNode.deps[0].key);
-
-      // if an atom/selector was successfully pushed into the recoilNodes array then the pointer should now point to the next key, which will have its own deps key if there is another atom/selector
-      currentNode = currentNode.next;
-    } else {
-      // This is the case where there is no atom/selector in the memoizedState. Look into the memoized state of the next key. If that doesn't exist then break from the while loop because there are no atoms/selectors at this point.
-      if (!currentNode.next) break;
-      if (!currentNode.next.memoizedState) break;
-      currentNode = currentNode.next.memoizedState;
+      if (
+        Array.isArray(currentNode.memoizedState.deps) &&
+        typeof currentNode.memoizedState.deps[0] === 'object'
+      ) {
+        // if recoilNodes (arr) includes the current atom or selector
+        if (recoilNodes.includes(currentNode.memoizedState.deps[0].key)) {
+          // do nothing
+          console.log('has');
+        } else {
+          // otherwise push atom/selector to recoilNodes
+          recoilNodes.push(currentNode.memoizedState.deps[0].key);
+        }
+      }
     }
+    // move onto next node
+    currentNode = currentNode.next;
   }
+  // return atom and selectors array
   return recoilNodes;
 };
 
@@ -72,7 +79,7 @@ const assignName = node => {
   if (node.tag === 7) return 'Fragment';
 };
 
-module.exports = {formatFiberNodes};
+module.exports = { formatFiberNodes };
 
 // if testing this function on the browser, use line below to log the formatted tree in the console
 //let formattedFiberNodes = formatFiberNodes(document.getElementById('root')._reactRootContainer._internalRoot.current)

--- a/package/index.js
+++ b/package/index.js
@@ -1,10 +1,10 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   useRecoilTransactionObserver_UNSTABLE,
   useRecoilSnapshot,
   useGotoRecoilSnapshot,
 } from 'recoil';
-import {formatFiberNodes} from './formatFiberNodes';
+import { formatFiberNodes } from './formatFiberNodes';
 
 // grabs isPersistedState from sessionStorage
 let isPersistedState = sessionStorage.getItem('isPersistedState');
@@ -29,7 +29,7 @@ export default function RecoilizeDebugger(props) {
 
   // Check if a root was passed to props.
   if (props.root) {
-    const {root} = props;
+    const { root } = props;
     recoilizeRoot = root;
   } else {
     recoilizeRoot = document.getElementById('root');
@@ -39,7 +39,6 @@ export default function RecoilizeDebugger(props) {
 
   // getNodes_UNSTABLE will return an iterable that contains atom and selector objects.
   const nodes = [...snapshot.getNodes_UNSTABLE()];
-
   // Local state of all previous snapshots to use for time traveling when requested by dev tools.
   const [snapshots, setSnapshots] = useState([snapshot]);
   // const [isRestoredState, setRestoredState] = useState(false);
@@ -236,7 +235,7 @@ export default function RecoilizeDebugger(props) {
   };
 
   // FOR TIME TRAVEL: Recoil hook to fire a callback on every atom/selector change -- research Throttle
-  useRecoilTransactionObserver_UNSTABLE(({snapshot}) => {
+  useRecoilTransactionObserver_UNSTABLE(({ snapshot }) => {
     const now = new Date().getTime();
     if (now - throttleTimer < throttleLimit) {
       isRestoredState = true;

--- a/src/app/components/ComponentGraph/AtomComponentVisual.tsx
+++ b/src/app/components/ComponentGraph/AtomComponentVisual.tsx
@@ -335,9 +335,9 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
 
       function colorComponents(d: any): string {
         // if component node contains recoil atoms or selectors, make it orange red or yellow, otherwise keep node gray
-      
+        
+        // console.log('hello from data! ', d.data)
         if (d.data.recoilNodes && d.data.recoilNodes.length) {
-    
           if (d.data.recoilNodes.includes(selectedRecoilValue[0])) {
             // Color of atom or selector when clicked on in legend
             return 'yellow';

--- a/src/extension/build/manifest.json
+++ b/src/extension/build/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Recoilize",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "devtools_page": "devtools.html",
   "description": "A Chrome extension that helps debug Recoil applications by memorizing the state of components with every render.",
   "manifest_version": 2,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Recoil 0.1.2 introduced a breaking change to the ComponentGraph. Making it so atoms or selectors weren't highlighted.
## Approach
Refactored the code to correctly identify atoms and selectors inside of ./package/formatFiberNodes.js