### PR TITLE
Fixed drop down children positioning so it wont overlap with suspense mode

### DIFF
--- a/src/app/components/ComponentGraph/AtomComponentVisual.tsx
+++ b/src/app/components/ComponentGraph/AtomComponentVisual.tsx
@@ -402,8 +402,8 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
         onClick={() => {
           setRawToggle(!rawToggle);
         }}>
+        <span>{rawToggle ? 'Collapse' : 'Expand'}</span>
       </button>
-      <span>{rawToggle ? 'Collapse' : 'Expand'}</span>
       <div className="AtomNetworkLegend">
         <div className="AtomLegend" />
         <p onClick={openDropdown} id="AtomP" className="AtomP">ATOM</p>

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -485,6 +485,7 @@ button:hover {
   background: transparent;
   border: none !important;
   margin-right: 5px;
+  cursor: pointer;
 }
 
 .AtomNetworkLegend {
@@ -532,7 +533,7 @@ button:hover {
 #atomDrop,
 #selectorDrop {
   display: grid;
-  grid-row: 4;
+  grid-row: 5;
   border: 0.1em solid rgb(43, 34, 34);
 }
 


### PR DESCRIPTION
…a suspended application

## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
When testing a suspended application, the drop down atom and selector menu would break the suspend legend icon.
## Approach
Adjusted positioning for children now it will display under suspense legend.